### PR TITLE
feat: [PAGOPA-2682] defining health check API

### DIFF
--- a/fdr/src/main/scala/eu/sia/pagopa/Main.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/Main.scala
@@ -294,7 +294,7 @@ object Main extends App {
           import akka.http.scaladsl.server.Directives._
           http
             .newServerAt(httpHost, httpPort)
-            .bind(routes.route ~ routes.routeSeed ~ routes.soapFunction(actorProps) ~ routes.restFunction(actorProps) ~ routes.restFunctionInternal(actorProps))
+            .bind(routes.route ~ routes.routeSeed ~ routes.infoRoute(actorProps) ~ routes.soapFunction(actorProps) ~ routes.restFunction(actorProps) ~ routes.restFunctionInternal(actorProps))
             .map(f => {
               if (job.isEmpty) {
                 log.info(s"Starting AkkaManagement...")

--- a/fdr/src/main/scala/eu/sia/pagopa/common/util/web/NodoRoute.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/common/util/web/NodoRoute.scala
@@ -488,6 +488,23 @@ case class NodoRoute(
     HttpResponse(status = StatusCodes.BadRequest, entity = HttpEntity(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`, payload))
   }
 
+  def infoRoute(actorProps: ActorProps): Route = {
+    path("info") {
+      get {
+        complete {
+          HttpEntity(
+            ContentTypes.`application/json`,
+            s"""{
+               |"version" : "${Constant.APP_VERSION}",
+               |"name" : "${Constant.APP_NAME}",
+               |"instance" : "${Constant.INSTANCE}",
+               |}""".stripMargin
+          )
+        }
+      }
+    }
+  }
+
   def soapFunction(actorProps: ActorProps): Route = {
     ignoreTrailingSlash {
       path("webservices" / "input") {

--- a/fdr/src/main/scala/eu/sia/pagopa/common/util/web/NodoRoute.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/common/util/web/NodoRoute.scala
@@ -497,7 +497,7 @@ case class NodoRoute(
             s"""{
                |\t"name" : "${Constant.APP_NAME}",
                |\t"version" : "${Constant.APP_VERSION}",
-               |\t"environment" : "${Constant.INSTANCE.toLowerCase()}",
+               |\t"environment" : "${Constant.INSTANCE.toLowerCase()}"
                |}""".stripMargin
           )
         }

--- a/fdr/src/main/scala/eu/sia/pagopa/common/util/web/NodoRoute.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/common/util/web/NodoRoute.scala
@@ -495,9 +495,9 @@ case class NodoRoute(
           HttpEntity(
             ContentTypes.`application/json`,
             s"""{
-               |"version" : "${Constant.APP_VERSION}",
-               |"name" : "${Constant.APP_NAME}",
-               |"instance" : "${Constant.INSTANCE}",
+               |\t"name" : "${Constant.APP_NAME}",
+               |\t"version" : "${Constant.APP_VERSION}",
+               |\t"environment" : "${Constant.INSTANCE.toLowerCase()}",
                |}""".stripMargin
           )
         }

--- a/helm-fdr/helm/Chart.yaml
+++ b/helm-fdr/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fdr-chart
 description: Flussi di rendicontazione
 type: application
-version: 0.22.0
-appVersion: 2.1.18-145-feat-healthcheck-api
+version: 0.23.0
+appVersion: 2.1.18-146-feat-healthcheck-api
 dependencies:
   - name: microservice-chart
     version: 3.0.0

--- a/helm-fdr/helm/Chart.yaml
+++ b/helm-fdr/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fdr-chart
 description: Flussi di rendicontazione
 type: application
-version: 0.23.0
-appVersion: 2.1.18-146-feat-healthcheck-api
+version: 0.24.0
+appVersion: 2.1.18-147-feat-healthcheck-api
 dependencies:
   - name: microservice-chart
     version: 3.0.0

--- a/helm-fdr/helm/Chart.yaml
+++ b/helm-fdr/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fdr-chart
 description: Flussi di rendicontazione
 type: application
-version: 0.21.0
-appVersion: 2.1.18
+version: 0.22.0
+appVersion: 2.1.18-145-feat-healthcheck-api
 dependencies:
   - name: microservice-chart
     version: 3.0.0

--- a/helm-fdr/helm/values-dev.yaml
+++ b/helm-fdr/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.1.18-145-feat-healthcheck-api
+    tag: 2.1.18-146-feat-healthcheck-api
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-dev.yaml
+++ b/helm-fdr/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.1.18
+    tag: 2.1.18-145-feat-healthcheck-api
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-dev.yaml
+++ b/helm-fdr/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.1.18-146-feat-healthcheck-api
+    tag: 2.1.18-147-feat-healthcheck-api
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-prod.yaml
+++ b/helm-fdr/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.1.18-145-feat-healthcheck-api
+    tag: 2.1.18-146-feat-healthcheck-api
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-prod.yaml
+++ b/helm-fdr/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.1.18
+    tag: 2.1.18-145-feat-healthcheck-api
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-prod.yaml
+++ b/helm-fdr/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.1.18-146-feat-healthcheck-api
+    tag: 2.1.18-147-feat-healthcheck-api
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-uat.yaml
+++ b/helm-fdr/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.1.18-145-feat-healthcheck-api
+    tag: 2.1.18-146-feat-healthcheck-api
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-uat.yaml
+++ b/helm-fdr/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.1.18
+    tag: 2.1.18-145-feat-healthcheck-api
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-uat.yaml
+++ b/helm-fdr/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.1.18-146-feat-healthcheck-api
+    tag: 2.1.18-147-feat-healthcheck-api
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione FASE 1",
     "description": "FDR - Flussi di rendicontazione FASE 1",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "2.1.18"
+    "version": "2.1.18-145-feat-healthcheck-api"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione FASE 1",
     "description": "FDR - Flussi di rendicontazione FASE 1",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "2.1.18-145-feat-healthcheck-api"
+    "version": "2.1.18-146-feat-healthcheck-api"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione FASE 1",
     "description": "FDR - Flussi di rendicontazione FASE 1",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "2.1.18-146-feat-healthcheck-api"
+    "version": "2.1.18-147-feat-healthcheck-api"
   },
   "servers": [
     {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.18-145-feat-healthcheck-api"
+ThisBuild / version := "2.1.18-146-feat-healthcheck-api"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.18"
+ThisBuild / version := "2.1.18-145-feat-healthcheck-api"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.18-146-feat-healthcheck-api"
+ThisBuild / version := "2.1.18-147-feat-healthcheck-api"


### PR DESCRIPTION
This PR contains a new endpoint, named `/info`, made in order to check the health status of FdR1 application on various environment. Currently, the main scope of its definition is its use on pagoPA Status Page.

#### List of Changes
 - Added new endpoint for health checks, needed on pagoPA Status Page

#### Motivation and Context
This change permits to add monitoring on this app for pagoPA Status Page

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
