### PR TITLE
refactor(soap): streamline processing of SOAP headers

### DIFF
--- a/fdr/src/main/scala/eu/sia/pagopa/common/message/SoapMessage.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/common/message/SoapMessage.scala
@@ -7,6 +7,7 @@ import java.time.LocalDateTime
 case class SoapRequest(
     override val sessionId: String,
     payload: String,
+    headers: Option[Seq[(String, String)]],
     callRemoteAddress: String,
     primitive: String,
     sender: String,

--- a/fdr/src/main/scala/eu/sia/pagopa/soapinput/actor/SoapActorPerRequest.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/soapinput/actor/SoapActorPerRequest.scala
@@ -237,6 +237,7 @@ class SoapActorPerRequest(
       soapRequest = SoapRequest(
         message.sessionId,
         message.payload,
+        message.headers,
         message.callRemoteAddress.getOrElse(""),
         primitiva,
         sender,


### PR DESCRIPTION
✨ Added method to check if SOAP message contains internal header.
 Refactored internal message processing logic for SOAP headers.

PAGOPA-2435

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
