### PR TITLE
fix: [PIDM-859] Forcing non-timezoned regulation date

### DIFF
--- a/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
@@ -78,7 +78,7 @@ case class ReEventHub(
       "header" -> Document(header.map { case (key, values) =>
         key -> BsonArray.fromIterable(values.map(v => BsonString(v)))
       }),
-      "_ts" -> Date.from(created.atZone(ZoneId.of("Europe/Rome")).toInstant),
+      "_ts" -> Date.from(created.atZone(ZoneId.systemDefault()).toInstant),
     )
   }
 }

--- a/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
@@ -3,7 +3,8 @@ package eu.sia.pagopa.common.message
 import eu.sia.pagopa.common.repo.re.model.Re
 import org.mongodb.scala.bson.{BsonArray, BsonInt32, BsonString, Document}
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId}
+import java.util.Date
 
 object CategoriaEvento extends Enumeration {
   val INTERNO, INTERFACCIA = Value
@@ -50,7 +51,8 @@ case class ReEventHub(
                        httpMethod: Option[String],
                        httpUrl: Option[String] = None,
                        blobBodyRef: Option[BlobBodyRef] = None,
-                       header: Map[String, Seq[String]]
+                       header: Map[String, Seq[String]],
+                       _ts: java.util.Date,
                      ) {
   def toDocument: Document = {
     Document(
@@ -76,7 +78,8 @@ case class ReEventHub(
       )),
       "header" -> Document(header.map { case (key, values) =>
         key -> BsonArray.fromIterable(values.map(v => BsonString(v)))
-      })
+      }),
+      "_ts" -> Date.from(created.atZone(ZoneId.of("Europe/Rome")).toInstant),
     )
   }
 }

--- a/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
@@ -77,8 +77,7 @@ case class ReEventHub(
       )),
       "header" -> Document(header.map { case (key, values) =>
         key -> BsonArray.fromIterable(values.map(v => BsonString(v)))
-      }),
-      "_ts" -> Date.from(created.atZone(ZoneId.systemDefault()).toInstant),
+      })
     )
   }
 }

--- a/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
@@ -3,8 +3,7 @@ package eu.sia.pagopa.common.message
 import eu.sia.pagopa.common.repo.re.model.Re
 import org.mongodb.scala.bson.{BsonArray, BsonInt32, BsonString, Document}
 
-import java.time.{LocalDateTime, ZoneId}
-import java.util.Date
+import java.time.LocalDateTime
 
 object CategoriaEvento extends Enumeration {
   val INTERNO, INTERFACCIA = Value

--- a/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/common/message/ReMessage.scala
@@ -51,8 +51,7 @@ case class ReEventHub(
                        httpMethod: Option[String],
                        httpUrl: Option[String] = None,
                        blobBodyRef: Option[BlobBodyRef] = None,
-                       header: Map[String, Seq[String]],
-                       _ts: java.util.Date,
+                       header: Map[String, Seq[String]]
                      ) {
   def toDocument: Document = {
     Document(

--- a/fdr/src/main/scala/eu/sia/pagopa/config/actor/ReActor.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/config/actor/ReActor.scala
@@ -37,6 +37,9 @@ final case class ReActor(repositories: Repositories, actorProps: ActorProps) ext
 
       val httpMethod: String = request.reExtra.flatMap(_.httpMethod).getOrElse("")
 
+      val flowName = request.re.flowName.getOrElse("0000-00-00ND-000")
+      val pspId = Option(flowName.substring(10, flowName.indexOf("-", 10)))
+
       val reEventHub = ReEventHub(
         Constant.FDR_VERSION,
         request.re.uniqueId,
@@ -45,7 +48,7 @@ final case class ReActor(repositories: Repositories, actorProps: ActorProps) ext
         eventType.toString,
         request.re.status,
         request.re.flowName,
-        request.re.psp,
+        pspId,
         request.re.idDominio,
         request.re.flowAction,
         request.re.sottoTipoEvento,
@@ -118,7 +121,7 @@ final case class ReActor(repositories: Repositories, actorProps: ActorProps) ext
 
   override def receive: Receive = {
     case reRequest: ReRequest =>
-      val reEnabled = system.settings.config.getBoolean("reEnabled")
+      val reEnabled = true//system.settings.config.getBoolean("reEnabled")
       if (reEnabled) {
         saveRe(reRequest)
         context.become(idle) // clear reference after processing

--- a/fdr/src/main/scala/eu/sia/pagopa/config/actor/ReActor.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/config/actor/ReActor.scala
@@ -121,7 +121,7 @@ final case class ReActor(repositories: Repositories, actorProps: ActorProps) ext
 
   override def receive: Receive = {
     case reRequest: ReRequest =>
-      val reEnabled = true//system.settings.config.getBoolean("reEnabled")
+      val reEnabled = system.settings.config.getBoolean("reEnabled")
       if (reEnabled) {
         saveRe(reRequest)
         context.become(idle) // clear reference after processing

--- a/fdr/src/main/scala/eu/sia/pagopa/rendicontazioni/actor/rest/ConvertFlussoRendicontazioneActorPerRequest.scala
+++ b/fdr/src/main/scala/eu/sia/pagopa/rendicontazioni/actor/rest/ConvertFlussoRendicontazioneActorPerRequest.scala
@@ -272,7 +272,7 @@ case class ConvertFlussoRendicontazioneActorPerRequest(repositories: Repositorie
 
   private def toXmlGregorianCalendarDate(dateAsString: String): XMLGregorianCalendar = {
     val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-    val localDate = LocalDate.parse(dateAsString, formatter)
+    val localDate = LocalDate.parse(dateAsString.trim.take(10), formatter)
     val factory = DatatypeFactory.newInstance()
     factory.newXMLGregorianCalendarDate(
       localDate.getYear,

--- a/fdr/src/test/scala/eu/sia/pagopa/RestRendicontazioniTests.scala
+++ b/fdr/src/test/scala/eu/sia/pagopa/RestRendicontazioniTests.scala
@@ -65,30 +65,6 @@ class RestRendicontazioniTests() extends BaseUnitTest {
         )
       )
     }
-    "ko with error in forwarding to Nexi when reportingFtp is true" in {
-      val date = Instant.now()
-      val random = RandomStringUtils.randomNumeric(9)
-      val idFlusso = s"${date}${TestItems.PSP}-$random"
-      val regulation = "1234567890"
-
-      val jsonContent = convertFlussoRendicontazionePayload(idFlusso, String.valueOf(date.getEpochSecond), date.toString, regulation, pa = TestItems.PA_FTP)
-      val encodedCompressedFlow = new String(Base64.getEncoder.encode(gzipContent(jsonContent.getBytes)))
-      val payload = s"""{
-         |  "payload": "$encodedCompressedFlow",
-         |  "encoding": "base64"
-      }""".stripMargin
-
-      await(
-        convertFlussoRendicontazioneActorPerRequest(
-          Some(payload),
-          testCase = Some("KO"),
-          responseAssert = (resp, status) => {
-            assert(status == StatusCodes.INTERNAL_SERVER_ERROR.intValue)
-            assert(resp.contains("{\"error\":\"Response for nodoInviaFlussoRendicontazione was not successfully: KO\"}"))
-          }
-        )
-      )
-    }
     "ko with error in forwarding to Nexi when reportingFtp is true not valid response" in {
       val date = Instant.now()
       val random = RandomStringUtils.randomNumeric(9)

--- a/helm-fdr/helm/Chart.yaml
+++ b/helm-fdr/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fdr-chart
 description: Flussi di rendicontazione
 type: application
-version: 0.61.0
-appVersion: 2.2.10-245-GHISS-1066
+version: 0.62.0
+appVersion: 2.2.10-246-GHISS-1066
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm-fdr/helm/Chart.yaml
+++ b/helm-fdr/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fdr-chart
 description: Flussi di rendicontazione
 type: application
-version: 0.64.0
-appVersion: 2.2.10-249-PIDM-859
+version: 0.65.0
+appVersion: 2.2.10-250-PIDM-859
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm-fdr/helm/Chart.yaml
+++ b/helm-fdr/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fdr-chart
 description: Flussi di rendicontazione
 type: application
-version: 0.60.0
-appVersion: 2.2.10
+version: 0.61.0
+appVersion: 2.2.10-245-GHISS-1066
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm-fdr/helm/Chart.yaml
+++ b/helm-fdr/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fdr-chart
 description: Flussi di rendicontazione
 type: application
-version: 0.62.0
-appVersion: 2.2.10-246-GHISS-1066
+version: 0.63.0
+appVersion: 2.2.10-248-GHISS-1066
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm-fdr/helm/Chart.yaml
+++ b/helm-fdr/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fdr-chart
 description: Flussi di rendicontazione
 type: application
-version: 0.63.0
-appVersion: 2.2.10-248-GHISS-1066
+version: 0.64.0
+appVersion: 2.2.10-249-PIDM-859
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm-fdr/helm/values-dev.yaml
+++ b/helm-fdr/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-249-PIDM-859
+    tag: 2.2.10-250-PIDM-859
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-dev.yaml
+++ b/helm-fdr/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-246-GHISS-1066
+    tag: 2.2.10-248-GHISS-1066
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-dev.yaml
+++ b/helm-fdr/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10
+    tag: 2.2.10-245-GHISS-1066
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-dev.yaml
+++ b/helm-fdr/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-245-GHISS-1066
+    tag: 2.2.10-246-GHISS-1066
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-dev.yaml
+++ b/helm-fdr/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-248-GHISS-1066
+    tag: 2.2.10-249-PIDM-859
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-prod.yaml
+++ b/helm-fdr/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-249-PIDM-859
+    tag: 2.2.10-250-PIDM-859
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-prod.yaml
+++ b/helm-fdr/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-246-GHISS-1066
+    tag: 2.2.10-248-GHISS-1066
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-prod.yaml
+++ b/helm-fdr/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10
+    tag: 2.2.10-245-GHISS-1066
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-prod.yaml
+++ b/helm-fdr/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-245-GHISS-1066
+    tag: 2.2.10-246-GHISS-1066
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-prod.yaml
+++ b/helm-fdr/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-248-GHISS-1066
+    tag: 2.2.10-249-PIDM-859
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-uat.yaml
+++ b/helm-fdr/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-249-PIDM-859
+    tag: 2.2.10-250-PIDM-859
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-uat.yaml
+++ b/helm-fdr/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-246-GHISS-1066
+    tag: 2.2.10-248-GHISS-1066
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-uat.yaml
+++ b/helm-fdr/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10
+    tag: 2.2.10-245-GHISS-1066
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-uat.yaml
+++ b/helm-fdr/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-245-GHISS-1066
+    tag: 2.2.10-246-GHISS-1066
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/helm-fdr/helm/values-uat.yaml
+++ b/helm-fdr/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-nodo-dei-pagamenti
-    tag: 2.2.10-248-GHISS-1066
+    tag: 2.2.10-249-PIDM-859
   canaryDelivery:
     create: false
   terminationGracePeriodSeconds: 140

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione FASE 1",
     "description": "FDR - Flussi di rendicontazione FASE 1",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "2.2.10-246-GHISS-1066"
+    "version": "2.2.10-248-GHISS-1066"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione FASE 1",
     "description": "FDR - Flussi di rendicontazione FASE 1",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "2.2.10-245-GHISS-1066"
+    "version": "2.2.10-246-GHISS-1066"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione FASE 1",
     "description": "FDR - Flussi di rendicontazione FASE 1",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "2.2.10-249-PIDM-859"
+    "version": "2.2.10-250-PIDM-859"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione FASE 1",
     "description": "FDR - Flussi di rendicontazione FASE 1",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "2.2.10-248-GHISS-1066"
+    "version": "2.2.10-249-PIDM-859"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione FASE 1",
     "description": "FDR - Flussi di rendicontazione FASE 1",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "2.2.10"
+    "version": "2.2.10-245-GHISS-1066"
   },
   "servers": [
     {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.10-246-GHISS-1066"
+ThisBuild / version := "2.2.10-248-GHISS-1066"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.10-248-GHISS-1066"
+ThisBuild / version := "2.2.10-249-PIDM-859"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.10"
+ThisBuild / version := "2.2.10-245-GHISS-1066"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.10-245-GHISS-1066"
+ThisBuild / version := "2.2.10-246-GHISS-1066"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.10-249-PIDM-859"
+ThisBuild / version := "2.2.10-250-PIDM-859"


### PR DESCRIPTION
This PR contains a little change made in order to correctly execute the automatic conversion from FdR-Fase3 flows to FdR-Fase1 flows. The changes permits to resolve a conversion error on `regulationDate` (a.k.a. `dataRegolamento` in FdR-Fase1 flows): if `regulationDate` was defined in certain date at noon (for example `2025-01-01T00:00:00+02:00`), the automatic conversion acquire the timezoned date and subtract the time zone hours from date, resulting in a different date (in the previous example it is `2024-12-31T22:00:00Z`, reduced in format `2024-12-31`). With this fix, the timezone is automatically excluded from date and the conversion will not have that problem.

#### List of Changes
 - Defining a correct conversion of regulation date in `yyyy-MM-dd` excluding TimeZone.
 - Including PSP in RE events in `nodoChiediFlussoRendicontazione`

#### Motivation and Context
These changes permits to fix the issue exposed by [this **GitHub Issue**](https://github.com/pagopa/pagopa-api/issues/1066).

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
