### PR TITLE
fix: Including extension for `az postgres flexible-server execute` command 

### DIFF
--- a/.devops/fdr-db-schema-pipelines.yml
+++ b/.devops/fdr-db-schema-pipelines.yml
@@ -69,6 +69,7 @@ stages:
                   USER=$2
                   PASS=$3
                   az config set extension.use_dynamic_install=yes_without_prompt
+                  az extension add --name rdbms-connect
                   az postgres flexible-server execute --name $(DB_HOST) --admin-user $(ADMIN_USERNAME) \
                   --admin-password '$(db-administrator-login-password)' --database-name "$(DATABASE_NAME)" \
                   --querytext "
@@ -96,6 +97,7 @@ stages:
               inlineScript: |
 
                 az config set extension.use_dynamic_install=yes_without_prompt
+                az extension add --name rdbms-connect
                 az postgres flexible-server execute --name $(DB_HOST) --admin-user $(ADMIN_USERNAME) \
                 --admin-password '$(db-administrator-login-password)' --database-name "$(DATABASE_NAME)" \
                 --querytext "


### PR DESCRIPTION
#### List of Changes
 - Including `rdbms-connect` extension for `execute` command against PGFlex servers

#### Motivation and Context
This PR includes a new directive on [fdr-db-schema-pipelines.yml](https://github.com/pagopa/pagopa-fdr-nodo-dei-pagamenti/pull/125/changes#diff-a992bfa8dd4e4fafe07f31e4ed7d726caca8e89487d5e764876dfae2e763592f) file. This new directive permits to download and install the `rdbms-connect` extension in Azure CLI, needed for `az postgres flexible-server execute` command. This is required because the new versions of Azure CLI did not natively contain this extension. 

#### How Has This Been Tested?
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
